### PR TITLE
fix: vertically center empty state block in chat

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -25,7 +25,7 @@ export function ChatInterface() {
   return (
     <div className="flex flex-col h-full p-4 overflow-hidden">
       <ScrollArea ref={scrollAreaRef} className="flex-1 overflow-hidden">
-        <div className="pr-4">
+        <div className="pr-4 h-full">
           <MessageList messages={messages} isLoading={status === "streaming"} />
         </div>
       </ScrollArea>


### PR DESCRIPTION
Add h-full to the wrapper div in ChatInterface so that the empty state block is vertically centered.

Closes #2

Generated with [Claude Code](https://claude.ai/code)