### PR TITLE
Center empty state block vertically in chat interface

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -25,7 +25,7 @@ export function ChatInterface() {
   return (
     <div className="flex flex-col h-full p-4 overflow-hidden">
       <ScrollArea ref={scrollAreaRef} className="flex-1 overflow-hidden">
-        <div className="pr-4 h-full">
+        <div className="pr-4 min-h-full flex flex-col">
           <MessageList messages={messages} isLoading={status === "streaming"} />
         </div>
       </ScrollArea>

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -13,7 +13,7 @@ interface MessageListProps {
 export function MessageList({ messages, isLoading }: MessageListProps) {
   if (messages.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full px-4 text-center">
+      <div className="flex flex-1 flex-col items-center justify-center px-4 text-center">
         <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-blue-50 mb-4 shadow-sm">
           <Bot className="h-7 w-7 text-blue-600" />
         </div>


### PR DESCRIPTION
Fixes #5 - adjusts the empty state block from top-aligned to vertically centered in the chat area.

Generated with [Claude Code](https://claude.ai/code)