### PR TITLE
fix: center empty state content vertically in chat

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -25,7 +25,7 @@ export function ChatInterface() {
   return (
     <div className="flex flex-col h-full p-4 overflow-hidden">
       <ScrollArea ref={scrollAreaRef} className="flex-1 overflow-hidden">
-        <div className="pr-4 min-h-full flex flex-col">
+        <div className="pr-4 min-h-full h-full flex flex-col">
           <MessageList messages={messages} isLoading={status === "streaming"} />
         </div>
       </ScrollArea>


### PR DESCRIPTION
Centers the empty state content vertically in the chat interface by adding `h-full` to the ScrollArea wrapper div in ChatInterface.tsx.

Closes #8

Generated with [Claude Code](https://claude.ai/code)